### PR TITLE
Update scantailor_bundler.command to codesign

### DIFF
--- a/bundler/scantailor_bundler.command
+++ b/bundler/scantailor_bundler.command
@@ -8,9 +8,7 @@
 # or 
 #    > brew install qt@6
 
-
 cd (dirname (status --current-filename))
-
 pwd 
 
 set NAME "ScanTailor (Advanced)"
@@ -25,10 +23,10 @@ set RELTRDIR "../share/scantailor-advanced/translations"
 
 cp -R "$TEMPLATE" "$TARGET"
 
-#update the plist and compile it
+# update the plist and compile it
 echo "INFO - updating the bundle PLIST…"
 set plist "$TARGET/Contents/Info.plist"
-set LC_CTYPE C && set LANG C && sed -i '' -e "s/\${Name}/$NAME/g" -e "s/\${Version}/$Version/g" -e "s/\${BundleVersion}/$BUNDLE_VERSION/"  $plist
+set LC_CTYPE C && set LANG C && sed -i '' -e "s/\${Name}/$NAME/g" -e "s/\${Version}/$Version/g" -e "s/\${BundleVersion}/$BUNDLE_VERSION/" $plist
 plutil -convert binary1 "$plist"
 
 echo "INFO - copying the binary…"
@@ -45,12 +43,23 @@ echo "INFO - relinking the binary …"
 chmod 755 "$TARGET/Contents/MacOS/ScanTailor"
 set qtprefix (brew --prefix qt)
 
-$qtprefix/bin/macdeployqt  "$TARGET"  -libpath="$qtprefix/lib"
+set devcert (security find-identity -v -p codesigning | grep -Eo '[0-9A-F]{40}' | head -n1)
 
-#DIRTY FIX FOR @rpath LINKING ISSUE
+$qtprefix/bin/macdeployqt "$TARGET" -libpath="$qtprefix/lib" -codesign="$devcert"
+
+# DIRTY FIX FOR @rpath LINKING ISSUE
 cp -R $qtprefix/lib/QtDBus.framework "$TARGET/Contents/Frameworks"
 set dbuslib (otool -L "$TARGET/Contents/Frameworks/QtDBus.framework/Versions/A/QtDBus" | grep -Eo "^.*/libdbus-[0-9.]+.dylib" | xargs)
 cp "$dbuslib" "$TARGET/Contents/Frameworks/"(basename $dbuslib)
 install_name_tool -change "$dbuslib" "@executable_path/../Frameworks/"(basename $dbuslib) "$TARGET/Contents/Frameworks/QtDBus.framework/Versions/A/QtDBus"
 
-echo "INFO - DONE ! "
+# Add the correct rpath to the executable so that @rpath resolves to the Frameworks folder.
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$TARGET/Contents/MacOS/ScanTailor"
+
+# Re-sign the entire app bundle using the certificate hash.
+codesign --force --deep --verbose=2 --sign "$devcert" "$TARGET"
+
+# Verify the signature.
+codesign --verify --verbose=4 "$TARGET"
+
+echo "INFO - DONE !"


### PR DESCRIPTION
Apple has stricter codesigning in recent years.

I resign the lib to get around the error seen here:

```
install_name_tool -change "$dbuslib" "@executable_path/../Frameworks/"(basename $dbuslib) "$TARGET/Contents/Frameworks/QtDBus.framework/Versions/A/QtDBus"

/Library/Developer/CommandLineTools/usr/bin/install_name_tool: warning: changes being made to the file will invalidate the code signature in: ./ScanTailor (Advanced).app/Contents/Frameworks/QtDBus.framework/Versions/A/QtDBus
```